### PR TITLE
Simply call the functions

### DIFF
--- a/lib/single-click-open.js
+++ b/lib/single-click-open.js
@@ -25,10 +25,10 @@ export function activate() {
   disposables = new CompositeDisposable();
 
   if (atom.config.get('single-click-open.fixTreeView'))
-    disposables.add(disablePendingItems());
+    disablePendingItems();
 
   if (atom.config.get('single-click-open.fixSearchResultsView'))
-    disposables.add(disableSearchResultDoubleClick());
+    disableSearchResultDoubleClick();
 }
 
 export function deactivate() {

--- a/lib/single-click-open.js
+++ b/lib/single-click-open.js
@@ -32,8 +32,8 @@ export function activate() {
 }
 
 export function deactivate() {
-  disposable.dispose();
-  disposable = null;
+  disposables.dispose();
+  disposables = null;
 }
 
 // No more pending pane items!


### PR DESCRIPTION
Don't pass the return values of the functions to `CompositeDisposable.add`.

It was probably never the correct behavior, and now the interface assertions are returning an error.  I believe that this fixes #3.
